### PR TITLE
[WIP] 商品詳細表示の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   protect_from_forgery except: :search
-  before_action :set_item, except: [:index, :new, :create, :show]
+  before_action :set_item, except: [:index, :new, :create]
   before_action :authenticate_user!, except: [:index, :show]
   before_action :access_right_check, except: [:index, :show, :new, :create]
 
@@ -15,13 +15,11 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-   
     if @item.save
       redirect_to root_path, notice: "出品が完了しました"
     else
       render :new
     end
-    
   end
 
   def edit
@@ -42,6 +40,7 @@ class ItemsController < ApplicationController
     else 
       render :show
     end
+  end
 
   def show
   end
@@ -50,8 +49,8 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :explanation, :price, :category, :item_status_id, :postage_type_id,
-    :postage_burden_id, :shipping_area_id, :shipping_date_id, :trading_status_id, images_attributes: [:src, :_destroy, :id],
-     brand_attributes: [:name]).merge(user_id: current_user.id)
+    :postage_burden_id, :shipping_area, :shipping_date_id, :trading_status_id, images_attributes: [:src, :_destroy, :id],
+    brand_attributes: [:name]).merge(user_id: current_user.id)
   end
 
   def set_item

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
 
   validates_associated :images
   validates :name, :images, :explanation, :category, :item_status_id, :postage_type_id,
-  :postage_burden_id, :shipping_area_id, :shipping_date_id, :trading_status_id, presence: true
+  :postage_burden_id, :shipping_area, :shipping_date_id, :trading_status_id, presence: true
   validates :price, numericality: { only_integer: true, greater_than: 299, less_than: 100000000}
   validates :explanation, length: { maximum: 1000 }
 
@@ -18,4 +18,5 @@ class Item < ApplicationRecord
   belongs_to_active_hash :postage_burden
   belongs_to_active_hash :shipping_date
   belongs_to_active_hash :trading_status
+
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -97,7 +97,7 @@
           %span
             必須
         .createMain__createContents__uploadDelivery__deliveryAreaSelect
-          = f.select(:shipping_area_id, JpPrefecture::Prefecture.all.collect {|p| [ p.name, p.code ] } + [ [ '未定', '48' ] ], {include_blank: '選択して下さい'}, {class: 'tag'}) 
+          = f.select(:shipping_area, JpPrefecture::Prefecture.all.collect {|p| [ p.name, p.name ] } + [ [ '未定', '48' ] ], {include_blank: '選択して下さい'}, {class: 'tag'}) 
           %i.fas.fa-chevron-down.tag-icon
         .createMain__createContents__uploadDelivery__deliveryDate
           %label

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -39,7 +39,7 @@
               %span
                 （税込）
               %span
-                - if @item.postage_burden == "送料込み(出品者負担)"
+                - if @item.postage_burden.name == "送料込み(出品者負担)"
                   送料込み
                 - else
                   送料別
@@ -94,17 +94,17 @@
                   %th
                     商品の状態
                   %td
-                    = @item.item_status
+                    = @item.item_status.name
                 %tr
                   %th
                     配送料の負担
                   %td
-                    = @item.postage_burden
+                    = @item.postage_burden.name
                 %tr
                   %th
                     配送の方法
                   %td
-                    = @item.postage_type
+                    = @item.postage_type.name
                 %tr
                   %th
                     発送元の地域
@@ -114,7 +114,7 @@
                   %th
                     発送日の目安
                   %td
-                    = @item.shipping_date
+                    = @item.shipping_date.name
           .main__showMain__topContent__itemBox__optionalArea          
             %ul 
               %li.optionalBtn.likeBtn

--- a/db/migrate/20200520124205_rename_column_shipping_area_of_items.rb
+++ b/db/migrate/20200520124205_rename_column_shipping_area_of_items.rb
@@ -1,0 +1,9 @@
+class RenameColumnShippingAreaOfItems < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :items, :shipping_area_id, :shipping_area
+  end
+
+  def down
+    rename_column :items, :shipping_area, :shipping_area_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_20_090259) do
+ActiveRecord::Schema.define(version: 2020_05_20_124205) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "firstname", null: false
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2020_05_20_090259) do
     t.string "item_status_id", null: false
     t.string "postage_type_id", null: false
     t.string "postage_burden_id", null: false
-    t.string "shipping_area_id", null: false
+    t.string "shipping_area", null: false
     t.string "shipping_date_id", null: false
     t.string "trading_status_id", default: "1", null: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
# What
- 出品機能で修正したカラムに適応させて、表示できるようにしました。
- jp_prefectureを使っている発送元地域名が、active_hashのようにidからだと上手く【地域名】を詳細画面で出力させることができなかったため、下記も修正。

1. 追加マイグレーションを追加し、itemsテーブルのshipping_area_idをshipping_areaに修正
2. それに付随してitems_controllerのストロングパラメータ、item.rbを修正
3. 出品時に、データが【地域名】で入るように修正

# Why
カラム名変更に伴い、エラーで表示できなくなった問題を修正する必要があったため。